### PR TITLE
Expand Git LFS criteria

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,61 @@
-*.csv filter=lfs diff=lfs merge=lfs -text
-*.tsv filter=lfs diff=lfs merge=lfs -text
-*.txt filter=lfs diff=lfs merge=lfs -text
-*.mdf filter=lfs diff=lfs merge=lfs -text
-*.ldf filter=lfs diff=lfs merge=lfs -text
+# Dataset file formats
+**/*.tsv filter=lfs diff=lfs merge=lfs -text
+**/*.TSV filter=lfs diff=lfs merge=lfs -text
+**/*.csv filter=lfs diff=lfs merge=lfs -text
+**/*.CSV filter=lfs diff=lfs merge=lfs -text
+**/*.txt filter=lfs diff=lfs merge=lfs -text
+**/*.TXT filter=lfs diff=lfs merge=lfs -text
+**/*.idv filter=lfs diff=lfs merge=lfs -text
+**/*.IDV filter=lfs diff=lfs merge=lfs -text
+**/*.TDV filter=lfs diff=lfs merge=lfs -text
+**/*.tdv filter=lfs diff=lfs merge=lfs -text
+**/*.psv filter=lfs diff=lfs merge=lfs -text
+**/*.PSV filter=lfs diff=lfs merge=lfs -text
+**/*.json filter=lfs diff=lfs merge=lfs -text
+**/*.JSON filter=lfs diff=lfs merge=lfs -text
+**/*.jsons filter=lfs diff=lfs merge=lfs -text
+**/*.JSONS filter=lfs diff=lfs merge=lfs -text
+**/*.parquet filter=lfs diff=lfs merge=lfs -text
+**/*.PARQUET filter=lfs diff=lfs merge=lfs -text
+**/*.Parquet filter=lfs diff=lfs merge=lfs -text
+**/*.xml filter=lfs diff=lfs merge=lfs -text
+**/*.XML filter=lfs diff=lfs merge=lfs -text
+**/*.dat filter=lfs diff=lfs merge=lfs -text
+**/*.DAT filter=lfs diff=lfs merge=lfs -text
+**/*.avro filter=lfs diff=lfs merge=lfs -text
+**/*.AVRO filter=lfs diff=lfs merge=lfs -text
+**/*.Avro filter=lfs diff=lfs merge=lfs -text
+**/*.arff filter=lfs diff=lfs merge=lfs -text
+**/*.ARFF filter=lfs diff=lfs merge=lfs -text
+**/*.libsvm filter=lfs diff=lfs merge=lfs -text
+**/*.LIBSVM filter=lfs diff=lfs merge=lfs -text
+**/*.svmlight filter=lfs diff=lfs merge=lfs -text
+**/*.SVMLIGHT filter=lfs diff=lfs merge=lfs -text
+**/*.ldf filter=lfs diff=lfs merge=lfs -text
+**/*.LDF filter=lfs diff=lfs merge=lfs -text
+**/*.mdf filter=lfs diff=lfs merge=lfs -text
+**/*.MDF filter=lfs diff=lfs merge=lfs -text
+
+# Image file formats
+**/*.png filter=lfs diff=lfs merge=lfs -text
+**/*.PNG filter=lfs diff=lfs merge=lfs -text
+**/*.jpg filter=lfs diff=lfs merge=lfs -text
+**/*.JPG filter=lfs diff=lfs merge=lfs -text
+**/*.jpeg filter=lfs diff=lfs merge=lfs -text
+**/*.JPEG filter=lfs diff=lfs merge=lfs -text
+**/*.tiff filter=lfs diff=lfs merge=lfs -text
+**/*.TIFF filter=lfs diff=lfs merge=lfs -text
+**/*.gif filter=lfs diff=lfs merge=lfs -text
+**/*.GIF filter=lfs diff=lfs merge=lfs -text
+
+# Compressed file formats
+**/*.gz filter=lfs diff=lfs merge=lfs -text
+**/*.GZ filter=lfs diff=lfs merge=lfs -text
+**/*.zip filter=lfs diff=lfs merge=lfs -text
+**/*.ZIP filter=lfs diff=lfs merge=lfs -text
+**/*.gzip filter=lfs diff=lfs merge=lfs -text
+**/*.GZIP filter=lfs diff=lfs merge=lfs -text
+**/*.bzip2 filter=lfs diff=lfs merge=lfs -text
+**/*.BZIP2 filter=lfs diff=lfs merge=lfs -text
+**/*.7z filter=lfs diff=lfs merge=lfs -text
+**/*.7Z filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Included additional dataset file formats for Git LFS. Image file extensions are included to support image datasets. Compressed file formats are included for datasets which come as a compressed bundle.